### PR TITLE
解决多行YAML value带入Go template的问题

### DIFF
--- a/template/build_config.yml
+++ b/template/build_config.yml
@@ -73,3 +73,33 @@ global:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAr5WIU6wES7WLrWTd3Y+vykAKERYdCzUne3xtlzk9tkcVTQ1IZ5I/cd+x7yw1BM69iRGkGWGRR4Z7k7CzQEbQ8udvK4KEOdZ+JWQfqm8XSlG4CA/cxevu55Trnp7kL4Kb5AtYxnIDhxS6NkrNrte5S4HBpQTA92DXtRW+nplyZ5TAk/qfOMcLoY1tdlTzGdPjWksvb13vvsBv8WkzqIXnBo+2ZJ9ZdieWLJlU0ExPqCH+kdPfv54kf7d8VY8+5jPXZ4IKGOMwi5929iVmkSzrKjvWdMT0aYSAzysohdchLbZcsm4iyQcAwU/J7kkZBbfvOcKr7EGQOif+F1Ag2LtNsQ== liuqs@Megatron"
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC866Ci5hod20ghEL+RDkEqKoAHOJtOwS18GiUGs3mrW5dAWrX22UJUTkNAh5SXKh60x/sRhItAAOscZ7zht6zzGfH1U2F2Thph1V3dPy7Fimo0c+rB4VXiQgZRZXKMUJ8rNUBO5avsjVH8gqmT5uyy6hUHqnqvug9PfVjaTunw6TBWSzVEqmsv8MpvH8lBBJ5WJidvXGNaYIB6l90/sm09SQJLheHVQJgFXbSJAOMRVKAoX4XCyAjPSnH4CLqNB8UvY9MGQKxTve2fCeUx8iSuE+Et8QrmF4wNo0Exh9Dsuk7OOr1hoZeECr+0pbahhwYIENjdXpT9lQoOxG35TjEB crawler@Crawler-01"
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDXena9hVzYpSHINYQyw2Flawjeja3PbcAGJPKmPCsl3sKkPygSXiN1zR8TOBiGrItX4aoLWBydmpn4wjis7RSVQIeeu1+Lk/qKm55zge6t3y1C38DSCPtW23mGvxojRbwAOzHjUqnrmP84g+MglNTaGod3HUMfzKd9YGTNm9QzcSRlmt87YGpsOQLJO0CQSJTwvSzNuH812a9kikdN5SR7OxUqbhxZE6vAk6glcVTrn/fxBY0i/l0LqHelJHGnMza4+jRs+p4Rp/QsLTaK60kfPYTpmJ6SfWrZBVAS0Oen5ZsPPTleu0okzy/20Iu/vrrW6OItEEvkCoLqtjANNUfn core@zodiac-01"
+
+  ssh_private_key: |2+
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEpQIBAAKCAQEA13p2vYVc2KUhyDWEMsNhZWsI3o2tz23ABiTypjwrJd7CpD8o
+          El4jdc0fEzgYhqyLV+GqC1gcnZqZ+MI4rO0UlUCHnrtfi5P6ipuec4Hurd8tQt/A
+          0gj7Vtt5hr8aI0W8ADsx41Kp65j/OIPjIJTU2hqHdx1DH8ynfWBkzZvUM3EkZZrf
+          O2BqbDkCyTtAkEiU8L0szbh/NdmvZIpHTeUkezsVKm4cWROrwJOoJXFU65/38QWN
+          Iv5dC6h3pSRxpzM2uPo0bPqeEaf0LC02iutJHz2E6Ziekn1q2QVQEtDnp+WbDz05
+          XrtKJM8v9tCLv7661ujiLRBL5AqC6rYwDTVH5wIDAQABAoIBAQC6GDHkjAEbucHr
+          PwzlKog7Jq2KR6IMuyRUKiTGHMDG/BPt9f2Nn2/QlU55MsE7zliplWNeWMKd+p9v
+          j42TC03zeL+n/vsNeMewXaYC6/xOfaiBUO0eeFNZOENEdFcGj3tGV9lGEmZd6szA
+          6maGBQOvOao03TjThdRBG7bzO9mQcljKte/kzLcy4rPKq03zyl8hVu8h6fE/MWK3
+          fRdju9mejf6jnBkrVUo12U654fQbteQIMQ8hanxPJDip0WTcqw3ZpFOKYhph7pM1
+          02OU7syb6LXkuqrk72ZmAOnCRJoeAa+9OicvNjM90vj+wZSJArr0vVXZDEm59bCT
+          y/OOdIFBAoGBAPBE+shhSyodPenJ5AltiZAaVKB70G/32Ojigv1D0bnU0uyrDm6r
+          J0AuUZ+t8QL6XzFX8c1vx9TT0yaDvmbsOb8IrkceWPZk/AfFwN0tHoh0+Q/pUv+p
+          K9yGF+pD50bQrAjP6VjeYMJnl+gpmtgcOjams9KiTWllYK5yU9aRl4u9AoGBAOWV
+          +ZiYK+uaqyx55iyuxpqxnkdi1erMzvEXnOoBA+fe//91OtuipCLdLbaa0EJSUzHI
+          ayv8n13gMZ9eW+FYTUH4gm60wK3X+qwU6FgrvzaA2WGU/A+W4bJpLva1szAnGfT2
+          J9JGZiuY2/6Fjecd0nAuXE7xei3WVtlib7RLDqpzAoGBAIXp/FiYmZskZzCZnOaA
+          Ta6qbkZwG9F8M0JBlT5xgT/w1YqhIE8gR6Um68ly2iSNxWasHJIi3h7J3SLXRNT6
+          jojh3ri2umDCEhKG7qKXli/5+iMbKW5jLJYhiszAAfRfM7NJpkYo04cm0+zK24nd
+          2bhCG3GnkjvPDB7Oi9nIlc2FAoGAUhNEkKXOBcNccGD/xXeR7pmS8QhHW1JupMgB
+          Q7KrN8iEEkpRiVVigkg54G8GBr+xmDmC/s2oF4Jfmw67oBrWO8BguL0LqNpudfhf
+          e63gBNcZX4ZIejZBZ2us62vXrF4+LFGXuNeMDQfvldUe/sGtioc4Xsx7Fknq8Hn9
+          XyH6EzsCgYEA76gePzfquN9hHr/Shs6kKYiO+/eVpS8oVtsRFuRx883hpVxdTYJv
+          OP9QZpPXHP46sRMYILtDXq5ou3e30+QJFXkI++4BQT3weW0SrfQFln8zWwR64hbl
+          oIgHr1a+OTKckCMK0hTellMVmHqAUwK49DHv3KM1soacfuRWyVIjDM8=
+          -----END RSA PRIVATE KEY-----
+

--- a/template/build_config.yml
+++ b/template/build_config.yml
@@ -1,0 +1,75 @@
+nodes:
+  "00:25:90:c0:f7:80":
+    ip: "10.10.10.201"
+    etcd_role: "member"
+    hostname: "zodiac-01"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f6:ee":
+    ip: "10.10.10.202"
+    etcd_role: "member"
+    hostname: "zodiac-02"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f6:d6":
+    ip: "10.10.10.203"
+    etcd_role: "member"
+    hostname: "zodiac-03"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:ac":
+    ip: "10.10.10.204"
+    etcd_role: "member"
+    hostname: "zodiac-04"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:7e":
+    ip: "10.10.10.205"
+    etcd_role: "member"
+    hostname: "zodiac-05"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:62":
+    ip: "10.10.10.206"
+    etcd_role: "proxy"
+    hostname: "zodiac-06"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:68":
+    ip: "10.10.10.207"
+    etcd_role: "proxy"
+    hostname: "zodiac-07"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:7a":
+    ip: "10.10.10.208"
+    etcd_role: "proxy"
+    hostname: "zodiac-08"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:c8":
+    ip: "10.10.10.209"
+    etcd_role: "proxy"
+    hostname: "zodiac-09"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:88":
+    ip: "10.10.10.210"
+    etcd_role: "proxy"
+    hostname: "zodiac-10"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:7c":
+    ip: "10.10.10.211"
+    etcd_role: "proxy"
+    hostname: "zodiac-11"
+    nic_name: "enp1s0f0"
+  "00:25:90:c0:f7:86":
+    ip: "10.10.10.212"
+    etcd_role: "proxy"
+    hostname: "zodiac-12"
+    nic_name: "enp1s0f0"
+  "00:e0:81:ee:82:c4":
+    ip: "10.10.10.191"
+    etcd_role: "proxy"
+    hostname: "coreos-191"
+    nic_name: "enp11s0f0"
+
+global:
+  ssh_authorized_keys: |2+
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzAy8KEKxDMmjd55RMKLFs8bhNGHgC+pvjbC7BOp4gibozfZAr84nWsfZPs44h1jMq0pX2qzGOpzGEN9RH/ALFCe/OixWkh+INnVTIr8scZr6M+3NzN+chBVGvmIAebUfhXrrP7pUXwK06T2MyT7HaDumfUiHF+n3vNIQTpsxnJA7lmx2IJvz6EujK9le75vJM19MsbUZDk61wuiqhbUZMwQEAKrWsvt9CPhqyHD2Ueul0cG/0fHqOXS/fw7Ikg29rUwdzRuYnvw6izuvBoaHF6nNxR+qSiVi3uyJdNox0/nd87OVvd0fE5xEz+xZ8aFwGyAZabo/KWgcMxk6WN0O1Q== lipeng@Megatron"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVwfLAgA8DICHp0//xfBTgfU34fVOtKpxgrkceC605HGQ6GIPsBHKw6CYeGziwZBDNtMZxTeyQ7+79sqA2VUR2I5nrhlxw/Wc80yTsjbRmcIbr3mUNCd3+cOqnOAsWEucZCHHcNYwUQ3wIOoyP0cBLKI4b25ucgtawxCmB7PJ1Cme+vIf1cVffeQqedu7hmlpQf/DnQc7O1iBRhEAqKgy1Y+hb0Ryc7StAe0nDHCj+2b08vHlNXaS2sJKrXUE0HhCZZP46APaLmZPmmHeoJKx31M0IERWYaZRvLe0Pl7Pp6DueOSJvvNwR5YbNe5aQ2pO3xiv3wCj6n66dlqAhpmmD vien.lee@localhost"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrYpsQVHBRUA/sZfxgK+9jZBGZfoulXXe0faPCGC0b3L6z/qYzJnNFf1d4gj6hQaGyHGvVlr6Kd/6y+0Eour51R2H+8FO+9Y7BaomuluHzm/jcgruAmbVrXZ8vKDDPDx4Lf1tnU1SqPpKFRgdro+BUcj/0LZ45tzsblpA2JOiMJkpqtx17WPKIzc9q5OZKVcV+zh/O+JuKLW/bDIndGiQRVJBGa87ZkCf+fzO5ME4nl7MsG/YY+9J/UkwDbZQd3wFTRqmHncrSupNhu1R2DttP9eWSHQsJIaEXmqKv4p7p4byztix3A/2hBUILZa3iDwxlCZq7OBrQCc/xOI45VMR7 liangjiameng@liangjiameng-Ubuntu"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAr5WIU6wES7WLrWTd3Y+vykAKERYdCzUne3xtlzk9tkcVTQ1IZ5I/cd+x7yw1BM69iRGkGWGRR4Z7k7CzQEbQ8udvK4KEOdZ+JWQfqm8XSlG4CA/cxevu55Trnp7kL4Kb5AtYxnIDhxS6NkrNrte5S4HBpQTA92DXtRW+nplyZ5TAk/qfOMcLoY1tdlTzGdPjWksvb13vvsBv8WkzqIXnBo+2ZJ9ZdieWLJlU0ExPqCH+kdPfv54kf7d8VY8+5jPXZ4IKGOMwi5929iVmkSzrKjvWdMT0aYSAzysohdchLbZcsm4iyQcAwU/J7kkZBbfvOcKr7EGQOif+F1Ag2LtNsQ== liuqs@Megatron"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC866Ci5hod20ghEL+RDkEqKoAHOJtOwS18GiUGs3mrW5dAWrX22UJUTkNAh5SXKh60x/sRhItAAOscZ7zht6zzGfH1U2F2Thph1V3dPy7Fimo0c+rB4VXiQgZRZXKMUJ8rNUBO5avsjVH8gqmT5uyy6hUHqnqvug9PfVjaTunw6TBWSzVEqmsv8MpvH8lBBJ5WJidvXGNaYIB6l90/sm09SQJLheHVQJgFXbSJAOMRVKAoX4XCyAjPSnH4CLqNB8UvY9MGQKxTve2fCeUx8iSuE+Et8QrmF4wNo0Exh9Dsuk7OOr1hoZeECr+0pbahhwYIENjdXpT9lQoOxG35TjEB crawler@Crawler-01"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDXena9hVzYpSHINYQyw2Flawjeja3PbcAGJPKmPCsl3sKkPygSXiN1zR8TOBiGrItX4aoLWBydmpn4wjis7RSVQIeeu1+Lk/qKm55zge6t3y1C38DSCPtW23mGvxojRbwAOzHjUqnrmP84g+MglNTaGod3HUMfzKd9YGTNm9QzcSRlmt87YGpsOQLJO0CQSJTwvSzNuH812a9kikdN5SR7OxUqbhxZE6vAk6glcVTrn/fxBY0i/l0LqHelJHGnMza4+jRs+p4Rp/QsLTaK60kfPYTpmJ6SfWrZBVAS0Oen5ZsPPTleu0okzy/20Iu/vrrW6OItEEvkCoLqtjANNUfn core@zodiac-01"

--- a/template/cloud-config.template
+++ b/template/cloud-config.template
@@ -1,0 +1,110 @@
+#cloud-config
+
+coreos:
+    etcd2:
+        discovery: "https://discovery.etcd.io/5e2d8844b9047f48d45fa70ab4a93765"{{if eq .EtcdRole "proxy" }}
+        proxy: "on"{{end}}
+        # multi-region and multi-cloud deployments need to use $public_ipv4
+        advertise-client-urls: "http://{{ .IP }}:2379"
+        initial-advertise-peer-urls: "http://{{ .IP }}:2380"
+        # listen on both the official ports and the legacy ports
+        # legacy ports can be omitted if your application doesn't depend on them
+        listen-client-urls: "http://0.0.0.0:2379,http://0.0.0.0:4001"
+        listen-peer-urls: "http://{{ .IP }}:2380,http://{{ .IP }}:7001"
+    update:
+        reboot-strategy: "etcd-lock"
+    locksmith:
+        window_start: "03:00"
+        window_length: "3h"
+    flannel:
+        interface: "{{ .IP }}"
+    units:
+        - name: "etcd2.service"
+          command: "start"
+        - name: "fleet.service"
+          command: "start"
+        - name: "docker.socket"
+          command: "start"
+        - name: "flanneld.service"
+          drop-ins:
+            - name: 50-network-config.conf
+              content: |
+                [Service]
+                ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
+          command: "start"
+        - name: "settimezone.service"
+          command: start
+          content: |
+            [Unit]
+            Description=Set the time zone
+
+            [Service]
+            ExecStart=/usr/bin/timedatectl set-timezone Asia/Shanghai
+            RemainAfterExit=yes
+            Type=oneshot
+
+hostname: "{{ .Hostname }}"
+
+ssh_authorized_keys:
+{{ .SSHAuthorizedKeys }}
+
+write_files:
+  - path: "/etc/resolv.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      nameserver 8.8.8.8
+  - path: "/etc/systemd/network/10-static.network"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [Match]
+      Name=enp1s0f0
+
+      [Network]
+      Address={{ .IP }}/24
+      Gateway=10.10.10.192
+
+      [Route]
+      Gateway=10.10.10.254
+      Destination=10.200.0.0/16
+
+      [Route]
+      Gateway=10.10.10.254
+      Destination=192.169.100.0/24
+
+      [Route]
+      Gateway=10.10.10.254
+      Destination=192.168.6.0/24
+  - path: "/home/core/.ssh/id_rsa"
+    permissions: "0600"
+    owner: "core"
+    content: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEpQIBAAKCAQEA13p2vYVc2KUhyDWEMsNhZWsI3o2tz23ABiTypjwrJd7CpD8o
+      El4jdc0fEzgYhqyLV+GqC1gcnZqZ+MI4rO0UlUCHnrtfi5P6ipuec4Hurd8tQt/A
+      0gj7Vtt5hr8aI0W8ADsx41Kp65j/OIPjIJTU2hqHdx1DH8ynfWBkzZvUM3EkZZrf
+      O2BqbDkCyTtAkEiU8L0szbh/NdmvZIpHTeUkezsVKm4cWROrwJOoJXFU65/38QWN
+      Iv5dC6h3pSRxpzM2uPo0bPqeEaf0LC02iutJHz2E6Ziekn1q2QVQEtDnp+WbDz05
+      XrtKJM8v9tCLv7661ujiLRBL5AqC6rYwDTVH5wIDAQABAoIBAQC6GDHkjAEbucHr
+      PwzlKog7Jq2KR6IMuyRUKiTGHMDG/BPt9f2Nn2/QlU55MsE7zliplWNeWMKd+p9v
+      j42TC03zeL+n/vsNeMewXaYC6/xOfaiBUO0eeFNZOENEdFcGj3tGV9lGEmZd6szA
+      6maGBQOvOao03TjThdRBG7bzO9mQcljKte/kzLcy4rPKq03zyl8hVu8h6fE/MWK3
+      fRdju9mejf6jnBkrVUo12U654fQbteQIMQ8hanxPJDip0WTcqw3ZpFOKYhph7pM1
+      02OU7syb6LXkuqrk72ZmAOnCRJoeAa+9OicvNjM90vj+wZSJArr0vVXZDEm59bCT
+      y/OOdIFBAoGBAPBE+shhSyodPenJ5AltiZAaVKB70G/32Ojigv1D0bnU0uyrDm6r
+      J0AuUZ+t8QL6XzFX8c1vx9TT0yaDvmbsOb8IrkceWPZk/AfFwN0tHoh0+Q/pUv+p
+      K9yGF+pD50bQrAjP6VjeYMJnl+gpmtgcOjams9KiTWllYK5yU9aRl4u9AoGBAOWV
+      +ZiYK+uaqyx55iyuxpqxnkdi1erMzvEXnOoBA+fe//91OtuipCLdLbaa0EJSUzHI
+      ayv8n13gMZ9eW+FYTUH4gm60wK3X+qwU6FgrvzaA2WGU/A+W4bJpLva1szAnGfT2
+      J9JGZiuY2/6Fjecd0nAuXE7xei3WVtlib7RLDqpzAoGBAIXp/FiYmZskZzCZnOaA
+      Ta6qbkZwG9F8M0JBlT5xgT/w1YqhIE8gR6Um68ly2iSNxWasHJIi3h7J3SLXRNT6
+      jojh3ri2umDCEhKG7qKXli/5+iMbKW5jLJYhiszAAfRfM7NJpkYo04cm0+zK24nd
+      2bhCG3GnkjvPDB7Oi9nIlc2FAoGAUhNEkKXOBcNccGD/xXeR7pmS8QhHW1JupMgB
+      Q7KrN8iEEkpRiVVigkg54G8GBr+xmDmC/s2oF4Jfmw67oBrWO8BguL0LqNpudfhf
+      e63gBNcZX4ZIejZBZ2us62vXrF4+LFGXuNeMDQfvldUe/sGtioc4Xsx7Fknq8Hn9
+      XyH6EzsCgYEA76gePzfquN9hHr/Shs6kKYiO+/eVpS8oVtsRFuRx883hpVxdTYJv
+      OP9QZpPXHP46sRMYILtDXq5ou3e30+QJFXkI++4BQT3weW0SrfQFln8zWwR64hbl
+      oIgHr1a+OTKckCMK0hTellMVmHqAUwK49DHv3KM1soacfuRWyVIjDM8=
+      -----END RSA PRIVATE KEY-----
+

--- a/template/cloud-config.template
+++ b/template/cloud-config.template
@@ -59,7 +59,7 @@ write_files:
     owner: "root"
     content: |
       [Match]
-      Name=enp1s0f0
+      Name={{ .NicName }}
 
       [Network]
       Address={{ .IP }}/24

--- a/template/cloud-config.template
+++ b/template/cloud-config.template
@@ -80,31 +80,4 @@ write_files:
     permissions: "0600"
     owner: "core"
     content: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIEpQIBAAKCAQEA13p2vYVc2KUhyDWEMsNhZWsI3o2tz23ABiTypjwrJd7CpD8o
-      El4jdc0fEzgYhqyLV+GqC1gcnZqZ+MI4rO0UlUCHnrtfi5P6ipuec4Hurd8tQt/A
-      0gj7Vtt5hr8aI0W8ADsx41Kp65j/OIPjIJTU2hqHdx1DH8ynfWBkzZvUM3EkZZrf
-      O2BqbDkCyTtAkEiU8L0szbh/NdmvZIpHTeUkezsVKm4cWROrwJOoJXFU65/38QWN
-      Iv5dC6h3pSRxpzM2uPo0bPqeEaf0LC02iutJHz2E6Ziekn1q2QVQEtDnp+WbDz05
-      XrtKJM8v9tCLv7661ujiLRBL5AqC6rYwDTVH5wIDAQABAoIBAQC6GDHkjAEbucHr
-      PwzlKog7Jq2KR6IMuyRUKiTGHMDG/BPt9f2Nn2/QlU55MsE7zliplWNeWMKd+p9v
-      j42TC03zeL+n/vsNeMewXaYC6/xOfaiBUO0eeFNZOENEdFcGj3tGV9lGEmZd6szA
-      6maGBQOvOao03TjThdRBG7bzO9mQcljKte/kzLcy4rPKq03zyl8hVu8h6fE/MWK3
-      fRdju9mejf6jnBkrVUo12U654fQbteQIMQ8hanxPJDip0WTcqw3ZpFOKYhph7pM1
-      02OU7syb6LXkuqrk72ZmAOnCRJoeAa+9OicvNjM90vj+wZSJArr0vVXZDEm59bCT
-      y/OOdIFBAoGBAPBE+shhSyodPenJ5AltiZAaVKB70G/32Ojigv1D0bnU0uyrDm6r
-      J0AuUZ+t8QL6XzFX8c1vx9TT0yaDvmbsOb8IrkceWPZk/AfFwN0tHoh0+Q/pUv+p
-      K9yGF+pD50bQrAjP6VjeYMJnl+gpmtgcOjams9KiTWllYK5yU9aRl4u9AoGBAOWV
-      +ZiYK+uaqyx55iyuxpqxnkdi1erMzvEXnOoBA+fe//91OtuipCLdLbaa0EJSUzHI
-      ayv8n13gMZ9eW+FYTUH4gm60wK3X+qwU6FgrvzaA2WGU/A+W4bJpLva1szAnGfT2
-      J9JGZiuY2/6Fjecd0nAuXE7xei3WVtlib7RLDqpzAoGBAIXp/FiYmZskZzCZnOaA
-      Ta6qbkZwG9F8M0JBlT5xgT/w1YqhIE8gR6Um68ly2iSNxWasHJIi3h7J3SLXRNT6
-      jojh3ri2umDCEhKG7qKXli/5+iMbKW5jLJYhiszAAfRfM7NJpkYo04cm0+zK24nd
-      2bhCG3GnkjvPDB7Oi9nIlc2FAoGAUhNEkKXOBcNccGD/xXeR7pmS8QhHW1JupMgB
-      Q7KrN8iEEkpRiVVigkg54G8GBr+xmDmC/s2oF4Jfmw67oBrWO8BguL0LqNpudfhf
-      e63gBNcZX4ZIejZBZ2us62vXrF4+LFGXuNeMDQfvldUe/sGtioc4Xsx7Fknq8Hn9
-      XyH6EzsCgYEA76gePzfquN9hHr/Shs6kKYiO+/eVpS8oVtsRFuRx883hpVxdTYJv
-      OP9QZpPXHP46sRMYILtDXq5ou3e30+QJFXkI++4BQT3weW0SrfQFln8zWwR64hbl
-      oIgHr1a+OTKckCMK0hTellMVmHqAUwK49DHv3KM1soacfuRWyVIjDM8=
-      -----END RSA PRIVATE KEY-----
-
+{{ .SSHPrivateKey }}    

--- a/template/template.go
+++ b/template/template.go
@@ -1,0 +1,38 @@
+package template
+
+import (
+	"io"
+	"os"
+	"text/template"
+)
+
+type PerNodeConfig struct {
+	IP       string `yaml:"ip"`
+	EtcdRole string `yaml:"etcd_role"`
+	Hostname string `yaml:"hostname"`
+	NicName  string `yaml:"nic_name"`
+}
+
+type GlobalConfig struct {
+	SSHAuthorizedKeys string `yaml:"ssh_authorized_keys"`
+}
+
+type ExecutionConfig struct {
+	PerNodeConfig
+	GlobalConfig
+}
+
+type Config struct {
+	Nodes  map[string]PerNodeConfig
+	Global GlobalConfig
+}
+
+// Execute returns the executed cloud-config template for a node with
+// given MAC address.
+func Execute(tmpl *template.Template, config *Config, mac string, w io.Writer) error {
+	ec := ExecutionConfig{
+		PerNodeConfig: config.Nodes[mac],
+		GlobalConfig:  config.Global,
+	}
+	return tmpl.Execute(os.Stdout, ec)
+}

--- a/template/template.go
+++ b/template/template.go
@@ -15,6 +15,7 @@ type PerNodeConfig struct {
 
 type GlobalConfig struct {
 	SSHAuthorizedKeys string `yaml:"ssh_authorized_keys"`
+	SSHPrivateKey     string `yaml:"ssh_private_key"`
 }
 
 type ExecutionConfig struct {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,0 +1,30 @@
+package template
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/topicai/candy"
+	"gopkg.in/yaml.v2"
+)
+
+func TestExecute(t *testing.T) {
+
+	config := candy.WithOpened("build_config.yml", func(r io.Reader) interface{} {
+		b, e := ioutil.ReadAll(r)
+		candy.Must(e)
+
+		c := &Config{}
+		assert.Nil(t, yaml.Unmarshal(b, &c))
+		return c
+	}).(*Config)
+
+	tmpl, e := template.ParseFiles("cloud-config.template")
+	candy.Must(e)
+
+	Execute(tmpl, config, "00:25:90:c0:f7:62", os.Stdout)
+}


### PR DESCRIPTION
这个简短的PR是我参照家盟和文山的Go/Python模板写的。主要解决家盟提出的多行YAML value如何带入Go template的问题。

具体的说，请注意我在[这里](https://github.com/k8sp/cloud-configs/compare/yi?expand=1#diff-9135e31a7e2b6021553d9e501928ff28R69) 和[这里](https://github.com/k8sp/cloud-configs/compare/yi?expand=1#diff-9135e31a7e2b6021553d9e501928ff28R77) 两处使用的 `|2+` 符号。这里 `|` 的意思是之后多行内容当做一个value——保留换行符，但是删掉行首空格。具体解释如 https://learnxinyminutes.com/docs/yaml/ 。在 `|` 之后加 `2+`，这里的2必须是接下来的值在 `build_config.yml` 里的 indentation level。大家可以看到我实际上在 `build_config.yml` 里给接下来的值加上了不少行首空格，这些空格中的头2个会被删掉，剩下的会被保留在parse之后的YAML value里。这就在value的每行行首加上了一些空格了。这些加上的空格是很必要的，因为parse的value会被带入到模板 文件`cloud-config.template` 中的[这里](https://github.com/k8sp/cloud-configs/compare/yi?expand=1#diff-5baa37d0626996f4a04cf56529fa208bR49) 和[这里](https://github.com/k8sp/cloud-configs/compare/yi?expand=1#diff-5baa37d0626996f4a04cf56529fa208bR83) 。

此外，这个PR展示了如何写Go的unit test。具体请参见`template_test.go`文件。我们在命令行里运行

```
go test -v
```

即可看到 `func TestExecute` 函数执行的输出。这个输出可以被拷贝粘贴到 CoreOS cloud-config Validator 里： https://coreos.com/validate/ 
